### PR TITLE
Implement external auth providers

### DIFF
--- a/src/BudgetPlaner.Api/BudgetPlaner.Api.csproj
+++ b/src/BudgetPlaner.Api/BudgetPlaner.Api.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Sqids" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BudgetPlaner.Api/EndpointDefinitions/ExternalAuthEndpointDefinitions.cs
+++ b/src/BudgetPlaner.Api/EndpointDefinitions/ExternalAuthEndpointDefinitions.cs
@@ -1,0 +1,81 @@
+using System.Security.Claims;
+using BudgetPlaner.Api.Bootstrap;
+using BudgetPlaner.Infrastructure.DatabaseContext;
+using BudgetPlaner.Infrastructure.UnitOfWork;
+using BudgetPlaner.Domain;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+
+namespace BudgetPlaner.Api.EndpointDefinitions;
+
+public class ExternalAuthEndpointDefinitions : IEndpointDefinition
+{
+    private const string BasePath = "/auth";
+
+    public void DefineEndpoints(WebApplication app)
+    {
+        var group = app.MapGroup(BasePath);
+        group.MapGet("/external/{provider}", ChallengeProvider);
+        group.MapGet("/external/{provider}/callback", HandleCallback);
+    }
+
+    public void DefineServices(IServiceCollection services)
+    {
+    }
+
+    private static IResult ChallengeProvider(string provider, string? returnUrl)
+    {
+        var redirectUrl = $"{BasePath}/external/{provider}/callback?returnUrl={Uri.EscapeDataString(returnUrl ?? "/")}";
+        var props = new AuthenticationProperties { RedirectUri = redirectUrl };
+        return Results.Challenge(props, [provider]);
+    }
+
+    private static async Task<IResult> HandleCallback(
+        string provider,
+        string? returnUrl,
+        HttpContext httpContext,
+        SignInManager<IdentityUser> signInManager,
+        UserManager<IdentityUser> userManager,
+        IUnitOfWork<BudgetPlanerContext> uow)
+    {
+        var info = await signInManager.GetExternalLoginInfoAsync();
+        if (info == null)
+        {
+            return Results.Redirect("/login");
+        }
+
+        var result = await signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, false);
+        IdentityUser user;
+        if (!result.Succeeded)
+        {
+            var email = info.Principal.FindFirstValue(ClaimTypes.Email) ?? string.Empty;
+            user = new IdentityUser { UserName = email, Email = email };
+            await userManager.CreateAsync(user);
+            await userManager.AddLoginAsync(user, info);
+        }
+        else
+        {
+            user = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey) ??
+                   await userManager.FindByEmailAsync(info.Principal.FindFirstValue(ClaimTypes.Email)!);
+        }
+
+        var repo = uow.Repository<UserProfileEntity>();
+        var profile = await repo.FirstOrDefaultAsync(x => x.UserId == user.Id);
+        if (profile == null)
+        {
+            await repo.AddAsync(new UserProfileEntity
+            {
+                UserId = user.Id,
+                Email = user.Email ?? string.Empty,
+                Provider = info.LoginProvider,
+                ProviderUserId = info.ProviderKey,
+                CreateDate = DateTime.UtcNow,
+                UpdateDate = DateTime.UtcNow
+            });
+            await uow.Complete();
+        }
+
+        await signInManager.SignInAsync(user, false, info.LoginProvider);
+        return Results.Redirect(returnUrl ?? "/");
+    }
+}

--- a/src/BudgetPlaner.Api/Program.cs
+++ b/src/BudgetPlaner.Api/Program.cs
@@ -109,6 +109,18 @@ builder.Services.AddAuthentication(options =>
             ValidateLifetime = true,
             ClockSkew = TimeSpan.FromSeconds(60) // Remove delay when token expires
         };
+    })
+    .AddGoogle(options =>
+    {
+        options.ClientId = builder.Configuration["Authentication:Google:ClientId"]!;
+        options.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"]!;
+        options.SignInScheme = IdentityConstants.ExternalScheme;
+    })
+    .AddFacebook(options =>
+    {
+        options.AppId = builder.Configuration["Authentication:Facebook:AppId"]!;
+        options.AppSecret = builder.Configuration["Authentication:Facebook:AppSecret"]!;
+        options.SignInScheme = IdentityConstants.ExternalScheme;
     });
 
 

--- a/src/BudgetPlaner.Domain/UserProfileEntity.cs
+++ b/src/BudgetPlaner.Domain/UserProfileEntity.cs
@@ -1,0 +1,8 @@
+namespace BudgetPlaner.Domain;
+
+public record UserProfileEntity : BaseEntity
+{
+    public string Email { get; set; } = string.Empty;
+    public string Provider { get; set; } = string.Empty;
+    public string ProviderUserId { get; set; } = string.Empty;
+}

--- a/src/BudgetPlaner.Infrastructure/DatabaseContext/BudgetPlanerContext.cs
+++ b/src/BudgetPlaner.Infrastructure/DatabaseContext/BudgetPlanerContext.cs
@@ -91,7 +91,11 @@ public class BudgetPlanerContext : DbContext
         modelBuilder.Entity<FinancialInsightEntity>().HasOne(x => x.Category)
             .WithMany()
             .HasForeignKey(x => x.CategoryId);
-            
+
+        // User profile
+        modelBuilder.Entity<UserProfileEntity>().HasKey(x => x.Id);
+        modelBuilder.Entity<UserProfileEntity>().ToTable(TableNames.UserProfile);
+
         // Loan payments
         modelBuilder.Entity<LoanPaymentEntity>().HasKey(x => x.Id);
         modelBuilder.Entity<LoanPaymentEntity>().ToTable(TableNames.LoanPayment);

--- a/src/BudgetPlaner.Infrastructure/TableNames.cs
+++ b/src/BudgetPlaner.Infrastructure/TableNames.cs
@@ -14,4 +14,5 @@ public static class TableNames
     public const string SavingsGoal = "SavingsGoal";
     public const string SavingsContribution = "SavingsContribution";
     public const string FinancialInsight = "FinancialInsight";
+    public const string UserProfile = "UserProfile";
 }

--- a/src/BudgetPlanerUI/Components/Pages/Auth/Login.razor
+++ b/src/BudgetPlanerUI/Components/Pages/Auth/Login.razor
@@ -100,8 +100,17 @@
 
                     <hr class="my-4">
 
+                    <div class="mb-3">
+                        <button type="button" class="btn btn-outline-danger w-100 mb-2" @onclick="() => ExternalLogin('Google')">
+                            <i class="bi bi-google me-2"></i> Continue with Google
+                        </button>
+                        <button type="button" class="btn btn-outline-primary w-100" @onclick="() => ExternalLogin('Facebook')">
+                            <i class="bi bi-facebook me-2"></i> Continue with Facebook
+                        </button>
+                    </div>
+
                     <div class="text-center">
-                        <p class="mb-0">Don't have an account? 
+                        <p class="mb-0">Don't have an account?
                             <a href="/register" class="text-decoration-none fw-bold">Sign up</a>
                         </p>
                     </div>
@@ -230,4 +239,10 @@
             isLoading = false;
         }
     }
-} 
+
+    private void ExternalLogin(string provider)
+    {
+        var url = $"/auth/external/{provider}?returnUrl={Uri.EscapeDataString(ReturnUrl ?? "/")}";
+        Navigation.NavigateTo(url, forceLoad: true);
+    }
+}


### PR DESCRIPTION
## Summary
- add Google and Facebook auth configuration
- create endpoint for external auth callbacks
- create user profile entity and map table
- offer Google and Facebook sign-in buttons on login page

## Testing
- `dotnet build BudgetPlaner.sln --no-restore` *(fails: command not found)*
- `dotnet test BudgetPlaner.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518f04b58c832bb62666a957cd6af4